### PR TITLE
stop writing index as a csv column

### DIFF
--- a/ebmdatalab/bq.py
+++ b/ebmdatalab/bq.py
@@ -45,5 +45,5 @@ def cached_read(sql,
         with open(fingerprint_path, "w") as f:
             f.write("File created by {}".format(__file__))
         df = pd.read_gbq(sql, **defaults)
-        df.to_csv(csv_path)
+        df.to_csv(csv_path, index=False)
     return df


### PR DESCRIPTION
`pd.to_csv` by default writes the index to the csv, which means that when the cached csv is read, there's an extra column when compared to when the query is run initially.