### PR TITLE
Remove deprecated argument

### DIFF
--- a/ebmdatalab/bq.py
+++ b/ebmdatalab/bq.py
@@ -28,7 +28,7 @@ def cached_read(sql, csv_path=None, use_cache=True, **kwargs):
 
     """
     assert csv_path, "You must supply csv_path"
-    defaults = {"verbose": False, "project_id": "ebmdatalab", "dialect": "standard"}
+    defaults = {"project_id": "ebmdatalab", "dialect": "standard"}
     defaults.update(kwargs)
     fingerprint = fingerprint_sql(sql)
     csv_dir, csv_filename = os.path.split(csv_path)


### PR DESCRIPTION
`verbose` is deprecated and gives a warning when the query is run