### PR TITLE
Support caching using zipped CSVs

### DIFF
--- a/ebmdatalab/__init__.py
+++ b/ebmdatalab/__init__.py
@@ -1,3 +1,3 @@
 """Package for ebmdatalab jupyter notebook stuff
 """
-__version__ = "0.0.20"
+__version__ = "0.0.21"

--- a/ebmdatalab/bq.py
+++ b/ebmdatalab/bq.py
@@ -41,17 +41,17 @@ def cached_read(sql, csv_path=None, use_cache=True, **kwargs):
     if use_cache and already_cached:
         df = pd.read_csv(csv_path)
     else:
+        temp_path = '{}.{}.tmp'.format(csv_path, _random_str(8))
+        df = pd.read_gbq(sql, **defaults)
+        df.to_csv(temp_path, index=False)
         old_fingerprint_files = glob.glob(
             os.path.join(csv_dir, "." + csv_filename + ".*.tmp")
         )
         for f in old_fingerprint_files:
             os.remove(f)
+        os.replace(temp_path, csv_path)
         with open(fingerprint_path, "w") as f:
             f.write("File created by {}".format(__file__))
-        temp_path = '{}.{}.tmp'.format(csv_path, _random_str(8))
-        df = pd.read_gbq(sql, **defaults)
-        df.to_csv(temp_path, index=False)
-        os.replace(temp_path, csv_path)
     return df
 
 

--- a/ebmdatalab/bq.py
+++ b/ebmdatalab/bq.py
@@ -41,7 +41,9 @@ def cached_read(sql, csv_path=None, use_cache=True, **kwargs):
     if use_cache and already_cached:
         df = pd.read_csv(csv_path)
     else:
-        temp_path = '{}.{}.tmp'.format(csv_path, _random_str(8))
+        temp_path = os.path.join(
+            csv_dir, '.tmp{}.{}'.format(_random_str(8), csv_filename)
+        )
         df = pd.read_gbq(sql, **defaults)
         df.to_csv(temp_path, index=False)
         old_fingerprint_files = glob.glob(


### PR DESCRIPTION
Previously, using a line like:
```python
bq.cached_read(sql, csv_path='ghost_generics.zip',use_cache=True)
```
would blow up with the error `BadZipFile: File is not a zip file` when attempting to read the cached file.