### PR TITLE
Make directories

### DIFF
--- a/ebmdatalab/bq.py
+++ b/ebmdatalab/bq.py
@@ -41,6 +41,7 @@ def cached_read(sql, csv_path=None, use_cache=True, **kwargs):
     if use_cache and already_cached:
         df = pd.read_csv(csv_path)
     else:
+        os.makedirs(csv_dir, exist_ok=True)
         temp_path = os.path.join(
             csv_dir, '.tmp{}.{}'.format(_random_str(8), csv_filename)
         )

--- a/ebmdatalab/tests/test_bq.py
+++ b/ebmdatalab/tests/test_bq.py
@@ -2,7 +2,8 @@ from mock import patch
 from ebmdatalab import bq
 from pandas import DataFrame
 import tempfile
-
+import pytest
+import os
 
 def test_fingerprint_sql():
     input_sql = 'select *, "Frob" from x -- comment\n' "where (a >= 4);"
@@ -39,6 +40,46 @@ def test_cached_read(mock_read_gbq):
         # and now with `use_cache` param
         df = bq.cached_read(sql, csv_path=csv_file.name, use_cache=False)
         assert mock_read_gbq.call_count == 2
+        assert False
+
+
+@patch("ebmdatalab.bq.pd.read_gbq")
+def test_cached_read_no_csv_path(mock_read_gbq):
+    mock_read_gbq.return_value = DataFrame([{"a": 3}])
+    sql = "select * from foobar"
+
+    # Test no csv path raises error
+    with tempfile.NamedTemporaryFile() as csv_file:
+        with pytest.raises(AssertionError) as exc_info:
+            df = bq.cached_read(sql, csv_path="")
+
+    assert "You must supply csv_path" in str(exc_info.value)
+
+
+@patch("ebmdatalab.bq.pd.read_gbq")
+def test_cached_read_non_existing_csv_dir_made(mock_read_gbq):
+    mock_read_gbq.return_value = DataFrame([{"a": 3}])
+    sql = "select * from foobar"
+
+    # Make temporary folder to save temporary files in
+    folder = tempfile.TemporaryDirectory()
+
+    with tempfile.NamedTemporaryFile(dir=folder.name) as csv_file:
+        # Test csv_dir exists
+        df = bq.cached_read(sql, csv_path=csv_file.name)
+        assert os.path.exists(folder.name)
+
+        # Delete contents of temporary folder
+        for file in os.listdir(folder.name):
+            os.remove(f"{folder.name}/{file}")
+
+        # Delete temporary folder
+        os.rmdir(folder.name)
+        assert os.path.exists(folder.name) is False
+
+        # Test temporary folder is remade
+        df = bq.cached_read(sql, csv_path=csv_file.name)
+        assert os.path.exists(folder.name)
 
 
 def _check_cached_read(csv_file, mock_read, sql, expected):


### PR DESCRIPTION
Closes #28 

### Problem
If the parent of csv_path doesn't exist then a confusing error is made. This is important because it is usually used from Jupyter notebooks so there is the added confusion of where exactly `pwd` is. 

### This PR
This PR adds in `os.makedirs()` to ensure that the parent directory of the csv file exists. 

I have also added in 2 further tests to test both the assertion occurs if no csv path passed in, and test the expected behaviour of the `os.makedirs() ` in use. 

`test_cached_read_non_existing_csv_dir_made` does the following:
1. Makes a temporary directory 
2. Makes a temporary file in this directory
3. Calls `bq.cached_read` on the path of this file and asserts path to folder exists 
4. Deletes the file and the folder
5. Calls `bq.cached_read` on the path of this file 
6. Asserts the folder is remade 