### PR TITLE
Decile changes for sro

### DIFF
--- a/ebmdatalab/charts.py
+++ b/ebmdatalab/charts.py
@@ -1,6 +1,7 @@
 import seaborn as sns
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 import matplotlib
 
 # Legend locations for matplotlib
@@ -24,18 +25,20 @@ def add_percentiles(df, period_column=None, column=None, show_outer_percentiles=
     Adds `percentile` column.
 
     """
-    deciles = np.arange(0.1, 1, 0.1)
-    bottom_percentiles = np.arange(0.01, 0.1, 0.01)
-    top_percentiles = np.arange(0.91, 1, 0.01)
+    quantiles = np.arange(0.1, 1, 0.1)
     if show_outer_percentiles:
-        quantiles = np.concatenate((deciles, bottom_percentiles, top_percentiles))
-    else:
-        quantiles = deciles
-    df = df.groupby(period_column)[column].quantile(quantiles).reset_index()
-    df = df.rename(index=str, columns={"level_1": "percentile"})
-    # create integer range of percentiles
-    df["percentile"] = df["percentile"].apply(lambda x: int(x * 100))
-    return df
+        quantiles = np.concatenate(
+            [quantiles, np.arange(0.01, 0.1, 0.01), np.arange(0.91, 1, 0.01)]
+        )
+    percentiles = (
+        df.groupby(period_column)[column]
+        .quantile(pd.Series(quantiles))
+        .reset_index()
+    )
+    percentiles = percentiles.rename(columns={"level_1": "percentile"})
+    percentiles["percentile"] = percentiles["percentile"] * 100
+    
+    return percentiles
 
 
 def deciles_chart(

--- a/ebmdatalab/charts.py
+++ b/ebmdatalab/charts.py
@@ -33,7 +33,7 @@ def add_percentiles(df, period_column=None, column=None, show_outer_percentiles=
     df = df.groupby(period_column)[column].quantile(quantiles).reset_index()
     df = df.rename(index=str, columns={"level_1": "percentile"})
     # create integer range of percentiles
-    df["percentile"] = df["percentile"].apply(lambda x: int(x * 100))
+    df["percentile"] = df["percentile"].apply(lambda x: x * 100)
     return df
 
 

--- a/ebmdatalab/charts.py
+++ b/ebmdatalab/charts.py
@@ -25,10 +25,10 @@ def add_percentiles(df, period_column=None, column=None, show_outer_percentiles=
     Adds `percentile` column.
 
     """
-    quantiles = np.arange(0.1, 1, 0.1)
+    quantiles = np.round(np.arange(0.1, 1, 0.1), 2)
     if show_outer_percentiles:
         quantiles = np.concatenate(
-            [quantiles, np.arange(0.01, 0.1, 0.01), np.arange(0.91, 1, 0.01)]
+            [quantiles, np.round(np.arange(0.01, 0.1, 0.01), 2), np.round(np.arange(0.91, 1, 0.01), 2)]
         )
     percentiles = (
         df.groupby(period_column)[column]

--- a/ebmdatalab/charts.py
+++ b/ebmdatalab/charts.py
@@ -21,24 +21,20 @@ CENTER = 10
 def add_percentiles(df, period_column=None, column=None, show_outer_percentiles=True):
     """For each period in `period_column`, compute percentiles across that
     range.
-
     Adds `percentile` column.
-
     """
-    quantiles = np.round(np.arange(0.1, 1, 0.1), 2)
+    deciles = np.arange(0.1, 1, 0.1)
+    bottom_percentiles = np.arange(0.01, 0.1, 0.01)
+    top_percentiles = np.arange(0.91, 1, 0.01)
     if show_outer_percentiles:
-        quantiles = np.concatenate(
-            [quantiles, np.round(np.arange(0.01, 0.1, 0.01), 2), np.round(np.arange(0.91, 1, 0.01), 2)]
-        )
-    percentiles = (
-        df.groupby(period_column)[column]
-        .quantile(pd.Series(quantiles))
-        .reset_index()
-    )
-    percentiles = percentiles.rename(columns={"level_1": "percentile"})
-    percentiles["percentile"] = percentiles["percentile"] * 100
-    
-    return percentiles
+        quantiles = np.concatenate((deciles, bottom_percentiles, top_percentiles))
+    else:
+        quantiles = deciles
+    df = df.groupby(period_column)[column].quantile(quantiles).reset_index()
+    df = df.rename(index=str, columns={"level_1": "percentile"})
+    # create integer range of percentiles
+    df["percentile"] = df["percentile"].apply(lambda x: int(x * 100))
+    return df
 
 
 def deciles_chart(

--- a/ebmdatalab/tests/test_charts.py
+++ b/ebmdatalab/tests/test_charts.py
@@ -3,11 +3,18 @@ import pandas as pd
 import numpy as np
 
 
+
+
+
 def test_add_percentiles():
     df = pd.DataFrame(np.random.rand(1000, 1), columns=["val"])
     months = pd.date_range("2018-01-01", periods=12, freq="M")
     df["month"] = np.random.choice(months, len(df))
     df = charts.add_percentiles(df, period_column="month", column="val")
+    
+    # We expect that each month has 27 percentiles (9 deciles, 9 bottom percentiles, 9 top percentiles)
+    assert (df.groupby(["month"])["percentile"].nunique().max() == (27))
+
     # This is a statistically-likely test, so might fail!
     assert (df[df.percentile == 99].val > 0.75).all()
 


### PR DESCRIPTION
OpenSAFELY SRO work uses the [deciles chart reusable action](https://actions.opensafely.org/actions/deciles-charts/v0.0.33/), which in turn uses the decile chart function here. 

When showing the outer percentiles, I was hitting a bug whereby some percentiles were repeated. This is a proposed fix, but there may be better ways to handle this.

This also refactors the function to compute deciles in passing, in line with previous SRO work by @iaindillingham.

