### PR TITLE
Support using a service account for BQ access

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,14 @@ df.head()
 
 ```
 
-To access data in BigQuery, users will need to have the credentials of a service account
-with "BigQuery Guest" and "BigQuery Dataset Guest" roles.  If using this library through
-a notebook derived from the datalab-jupyter image, the credentials should be stored in
-the repo root.  Otherwise, `EBMDATALAB_BQ_CREDENTIALS_PATH` should be set to the path of
-the credentials file.
+To access data in BigQuery, users will need to have the credentials of a service account with "BigQuery Guest" and "BigQuery Dataset Guest" roles.
+You can do that [here](https://console.cloud.google.com/iam-admin/serviceaccounts?project=ebmdatalab).
+
+* Click "+ CREATE SERVICE ACCOUNT", choose a name for the account (eg "Rich Croker service account"), and add the "BigQuery Guest" and "BigQuery Dataset Guest" roles.
+* Select the newly created account, click "KEYS", "ADD KEY", "Create new key", "JSON", and "CREATE".  This will download the credentials.
+
+If using this library through a notebook derived from the datalab-jupyter image, the credentials file should be renamed to `bq-service-account.json` and moved to the repo root.
+Otherwise, `EBMDATALAB_BQ_CREDENTIALS_PATH` should be set to the path of the credentials file.
 
 
 ### Other functions

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install the package as you usually would, e.g.
 
     pip install ebmdatalab
 
-### Convenience for caching/storing bigquery data as CSV
+### Convenience for caching/storing BigQuery data as CSV
 
 This will save the results of the SQL query as a CSV, and when it's
 run again, as long as the SQL hasn't changed, load that CSV rather
@@ -28,6 +28,11 @@ df.head()
 
 ```
 
+To access data in BigQuery, users will need to have the credentials of a service account
+with "BigQuery Guest" and "BigQuery Dataset Guest" roles.  If using this library through
+a notebook derived from the datalab-jupyter image, the credentials should be stored in
+the repo root.  Otherwise, `EBMDATALAB_BQ_CREDENTIALS_PATH` should be set to the path of
+the credentials file.
 
 
 ### Other functions
@@ -78,6 +83,3 @@ importlib.reload(charts)
    - Describe and commit changes.
    - Make a pull request to merge branch with master (select from dropdown menu under `Branch`). 
    - This will take you to GitHub where you need to click `Create pull request`
- 
- 
- 

--- a/ebmdatalab/__init__.py
+++ b/ebmdatalab/__init__.py
@@ -1,3 +1,3 @@
 """Package for ebmdatalab jupyter notebook stuff
 """
-__version__ = "0.0.25"
+__version__ = "0.0.28"

--- a/ebmdatalab/__init__.py
+++ b/ebmdatalab/__init__.py
@@ -1,3 +1,3 @@
 """Package for ebmdatalab jupyter notebook stuff
 """
-__version__ = "0.0.28"
+__version__ = "0.0.29"

--- a/ebmdatalab/bq.py
+++ b/ebmdatalab/bq.py
@@ -5,6 +5,7 @@ import re
 from hashlib import md5
 import string
 
+from google.oauth2.service_account import Credentials
 import pandas as pd
 
 
@@ -33,7 +34,7 @@ def cached_read(sql, csv_path=None, use_cache=True, **kwargs):
     defaults = {
         "project_id": "ebmdatalab",
         "dialect": "standard",
-        "auth_local_webserver": True,
+        "credentials": load_credentials(),
     }
     defaults.update(kwargs)
     fingerprint = fingerprint_sql(sql)
@@ -66,3 +67,13 @@ def _random_str(length):
     return ''.join(
         [random.choice(string.ascii_lowercase) for _ in range(length)]
     )
+
+
+def load_credentials():
+    # To authenticate with a service account EBMDATALAB_BQ_CREDENTIALS_PATH should be
+    # the path of a file containing the service account's private key.  See README.md
+    # for requirements of the service account.
+    path = os.getenv("EBMDATALAB_BQ_CREDENTIALS_PATH")
+    if path is None:
+        return
+    return Credentials.from_service_account_file(path)

--- a/ebmdatalab/bq.py
+++ b/ebmdatalab/bq.py
@@ -31,12 +31,6 @@ def cached_read(sql, csv_path=None, use_cache=True, **kwargs):
 
     """
     assert csv_path, "You must supply csv_path"
-    defaults = {
-        "project_id": "ebmdatalab",
-        "dialect": "standard",
-        "credentials": load_credentials(),
-    }
-    defaults.update(kwargs)
     fingerprint = fingerprint_sql(sql)
     csv_dir, csv_filename = os.path.split(csv_path)
     fingerprint_path = os.path.join(
@@ -44,22 +38,28 @@ def cached_read(sql, csv_path=None, use_cache=True, **kwargs):
     )
     already_cached = os.path.exists(fingerprint_path)
     if use_cache and already_cached:
-        df = pd.read_csv(csv_path)
-    else:
-        os.makedirs(csv_dir, exist_ok=True)
-        temp_path = os.path.join(
-            csv_dir, '.tmp{}.{}'.format(_random_str(8), csv_filename)
-        )
-        df = pd.read_gbq(sql, **defaults)
-        df.to_csv(temp_path, index=False)
-        old_fingerprint_files = glob.glob(
-            os.path.join(csv_dir, "." + csv_filename + ".*.tmp")
-        )
-        for f in old_fingerprint_files:
-            os.remove(f)
-        os.replace(temp_path, csv_path)
-        with open(fingerprint_path, "w") as f:
-            f.write("File created by {}".format(__file__))
+        return pd.read_csv(csv_path)
+
+    defaults = {
+        "project_id": "ebmdatalab",
+        "dialect": "standard",
+        "credentials": load_credentials(),
+    }
+    defaults.update(kwargs)
+    os.makedirs(csv_dir, exist_ok=True)
+    temp_path = os.path.join(
+        csv_dir, '.tmp{}.{}'.format(_random_str(8), csv_filename)
+    )
+    df = pd.read_gbq(sql, **defaults)
+    df.to_csv(temp_path, index=False)
+    old_fingerprint_files = glob.glob(
+        os.path.join(csv_dir, "." + csv_filename + ".*.tmp")
+    )
+    for f in old_fingerprint_files:
+        os.remove(f)
+    os.replace(temp_path, csv_path)
+    with open(fingerprint_path, "w") as f:
+        f.write("File created by {}".format(__file__))
     return df
 
 
@@ -75,5 +75,6 @@ def load_credentials():
     # for requirements of the service account.
     path = os.getenv("EBMDATALAB_BQ_CREDENTIALS_PATH")
     if path is None:
+        # If no credentials are provided, users will have to authenticate via OAuth.
         return
     return Credentials.from_service_account_file(path)


### PR DESCRIPTION
The out-of-band oauth workflow that we have previously relied on is deprecated, and I haven't been able to get the new oauth workflow (which involves starting a server on localhost to listen for a callback) to work on Docker.