### PR TITLE
Fix deprecated use of `pandas.read_gbq()`

### DIFF
--- a/ebmdatalab/__init__.py
+++ b/ebmdatalab/__init__.py
@@ -1,3 +1,3 @@
 """Package for ebmdatalab jupyter notebook stuff
 """
-__version__ = "0.0.30"
+__version__ = "0.0.31"

--- a/ebmdatalab/bq.py
+++ b/ebmdatalab/bq.py
@@ -7,6 +7,7 @@ import string
 
 from google.oauth2.service_account import Credentials
 import pandas as pd
+import pandas_gbq
 
 
 def fingerprint_sql(sql):
@@ -50,7 +51,7 @@ def cached_read(sql, csv_path=None, use_cache=True, **kwargs):
     temp_path = os.path.join(
         csv_dir, '.tmp{}.{}'.format(_random_str(8), csv_filename)
     )
-    df = pd.read_gbq(sql, **defaults)
+    df = pandas_gbq.read_gbq(sql, **defaults)
     df.to_csv(temp_path, index=False)
     old_fingerprint_files = glob.glob(
         os.path.join(csv_dir, "." + csv_filename + ".*.tmp")


### PR DESCRIPTION
This was generating the warning message:

    FutureWarning: read_gbq is deprecated and will be removed in a future version.
    Please use pandas_gbq.read_gbq instead:
    https://pandas-gbq.readthedocs.io/en/latest/api.html#pandas_gbq.read_gbq